### PR TITLE
Show notice with picture element field

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -32,7 +32,7 @@ function webp_uploads_get_upload_image_mime_transforms(): array {
 	);
 
 	// Check setting for whether to generate both JPEG and the modern output format.
-	if ( webp_uploads_is_generate_webp_and_jpeg_enabled() ) {
+	if ( webp_uploads_is_jpeg_fallback_enabled() ) {
 		$default_transforms = array(
 			'image/jpeg'              => array( 'image/jpeg', 'image/' . $output_format ),
 			'image/' . $output_format => array( 'image/' . $output_format, 'image/jpeg' ),

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -154,7 +154,7 @@ function webp_uploads_generate_avif_webp_setting_callback(): void {
 	<p class="description" id="perflab_modern_image_format_description"><?php esc_html_e( 'Select the format to use when generating new images from uploaded JPEGs.', 'webp-uploads' ); ?></p>
 	<?php if ( ! $avif_supported ) : ?>
 		<br />
-		<div class="notice notice-warning is-dismissible inline">
+		<div class="notice notice-warning inline">
 			<p><b><?php esc_html_e( 'AVIF support is not available.', 'webp-uploads' ); ?></b></p>
 			<p><?php esc_html_e( 'AVIF support can only be enabled by your hosting provider, so contact them for more information.', 'webp-uploads' ); ?></p>
 		</div>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -204,12 +204,12 @@ function webp_uploads_use_picture_element_callback(): void {
 			opacity: 0.7;
 		}
 	</style>
-	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php if ( $jpeg_fallback_enabled ) { echo 'hidden'; } ?>>
+	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php echo $jpeg_fallback_enabled ? 'hidden' : ''; ?>>
 		<p><?php esc_html_e( 'This setting requires JPEG also be output as a fallback option.', 'webp-uploads' ); ?></p>
 	</div>
-	<div id="webp_uploads_picture_element_fieldset" class="<?php if ( ! $jpeg_fallback_enabled ) { echo 'disabled'; } ?>">
+	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php if ( ! $jpeg_fallback_enabled ) { echo 'disabled'; } ?>" >
+			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" >
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -97,6 +97,11 @@ function webp_uploads_add_media_settings_fields(): void {
 		array( 'class' => 'perflab-generate-webp-and-jpeg' )
 	);
 
+	$class = 'webp-uploads-use-picture-element';
+	if ( ! webp_uploads_is_generate_webp_and_jpeg_enabled() ) {
+		$class .= ' hidden';
+	}
+
 	// Add picture element support settings field.
 	add_settings_field(
 		'webp_uploads_use_picture_element',
@@ -104,7 +109,7 @@ function webp_uploads_add_media_settings_fields(): void {
 		'webp_uploads_use_picture_element_callback',
 		'media',
 		'perflab_modern_image_format_settings',
-		array( 'class' => 'webp-uploads-use-picture-element' )
+		array( 'class' => $class )
 	);
 }
 add_action( 'admin_init', 'webp_uploads_add_media_settings_fields' );
@@ -180,26 +185,9 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
 		<script>
 			// Listen for clicks on the JPEG output checkbox, enabling/disabling the
 			// picture element checkbox accordingly.
-			document.addEventListener( 'DOMContentLoaded', function() {
-				var jpegCheckbox               = document.getElementById( 'perflab_generate_webp_and_jpeg' );
-				var pictureCheckbox            = document.getElementById( 'webp_uploads_use_picture_element' );
-				var pictureCheckboxLabel       = document.getElementById( 'webp_uploads_use_picture_element_label' );
-				var pictureCheckboxDescription = document.getElementById( 'webp_uploads_use_picture_element_description' );
-
-				function togglePictureCheckbox() {
-					if ( jpegCheckbox.checked ) {
-						pictureCheckbox.removeAttribute( 'disabled' );
-						pictureCheckboxLabel.classList.remove( 'webp-uploads-disabled' );
-						pictureCheckboxDescription.classList.remove( 'webp-uploads-disabled' );
-					} else {
-						pictureCheckbox.setAttribute( 'disabled', 'disabled' );
-						pictureCheckboxLabel.classList.add( 'webp-uploads-disabled' );
-						pictureCheckboxDescription.classList.add( 'webp-uploads-disabled' );
-					}
-				}
-
-				jpegCheckbox.addEventListener( 'change', togglePictureCheckbox );
-			});
+			document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
+				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'hidden', ! this.checked );
+			} );
 		</script>
 	<?php
 }
@@ -210,21 +198,13 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
  * @since n.e.x.t
  */
 function webp_uploads_use_picture_element_callback(): void {
-	// Picture element support requires the JPEG output to be enabled.
-	$jpeg_disabled = ! webp_uploads_is_generate_webp_and_jpeg_enabled();
 	?>
-		<style>
-			.webp-uploads-disabled {
-				color #a7aaad;
-				opacity: 0.5;
-			}
-		</style>
-		<label for="webp_uploads_use_picture_element" class="<?php echo $jpeg_disabled ? 'webp-uploads-disabled' : ''; ?>" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> <?php disabled( $jpeg_disabled ); ?>/>
+		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
+			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?>>
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>
-		<p class="description<?php echo $jpeg_disabled ? ' webp-uploads-disabled' : ''; ?>" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to JPEG. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
+		<p class="description" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to JPEG. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
 	<?php
 }
 

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -97,11 +97,6 @@ function webp_uploads_add_media_settings_fields(): void {
 		array( 'class' => 'perflab-generate-webp-and-jpeg' )
 	);
 
-	$class = 'webp-uploads-use-picture-element';
-	if ( ! webp_uploads_is_jpeg_fallback_enabled() ) {
-		$class .= ' hidden';
-	}
-
 	// Add picture element support settings field.
 	add_settings_field(
 		'webp_uploads_use_picture_element',
@@ -109,7 +104,7 @@ function webp_uploads_add_media_settings_fields(): void {
 		'webp_uploads_use_picture_element_callback',
 		'media',
 		'perflab_modern_image_format_settings',
-		array( 'class' => $class )
+		array( 'class' => 'webp-uploads-use-picture-element' )
 	);
 }
 add_action( 'admin_init', 'webp_uploads_add_media_settings_fields' );
@@ -186,7 +181,10 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
 			// Listen for clicks on the JPEG output checkbox, enabling/disabling the
 			// picture element checkbox accordingly.
 			document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
-				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'hidden', ! this.checked );
+				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
+				document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
+				document.getElementById( 'webp_uploads_use_picture_element' ).classList.toggle( 'disabled', ! this.checked );
+				document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
 			} );
 		</script>
 	<?php
@@ -198,13 +196,25 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
  * @since n.e.x.t
  */
 function webp_uploads_use_picture_element_callback(): void {
+	$jpeg_fallback_enabled = webp_uploads_is_jpeg_fallback_enabled();
 	?>
+	<style>
+		#webp_uploads_picture_element_fieldset.disabled label,
+		#webp_uploads_picture_element_fieldset.disabled p {
+			opacity: 0.7;
+		}
+	</style>
+	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php if ( $jpeg_fallback_enabled ) { echo 'hidden'; } ?>>
+		<p><?php esc_html_e( 'This setting requires JPEG also be output as a fallback option.', 'webp-uploads' ); ?></p>
+	</div>
+	<div id="webp_uploads_picture_element_fieldset" class="<?php if ( ! $jpeg_fallback_enabled ) { echo 'disabled'; } ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?>>
+			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php if ( ! $jpeg_fallback_enabled ) { echo 'disabled'; } ?>" >
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>
 		<p class="description" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to JPEG. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
+	</div>
 	<?php
 }
 

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -120,8 +120,6 @@ add_action( 'admin_init', 'webp_uploads_add_media_settings_fields' );
  * @since n.e.x.t
  */
 function webp_uploads_generate_avif_webp_setting_callback(): void {
-
-	$selected       = webp_uploads_get_image_output_format();
 	$avif_supported = webp_uploads_mime_type_supported( 'image/avif' );
 	$webp_supported = webp_uploads_mime_type_supported( 'image/webp' );
 

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -203,7 +203,7 @@ function webp_uploads_use_picture_element_callback(): void {
 			opacity: 0.7;
 		}
 	</style>
-	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php echo $jpeg_fallback_enabled ? 'hidden' : ''; ?>>
+	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php echo ! $jpeg_fallback_enabled ? 'hidden' : ''; ?>>
 		<p><?php esc_html_e( 'This setting requires JPEG also be output as a fallback option.', 'webp-uploads' ); ?></p>
 	</div>
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -120,6 +120,8 @@ add_action( 'admin_init', 'webp_uploads_add_media_settings_fields' );
  * @since n.e.x.t
  */
 function webp_uploads_generate_avif_webp_setting_callback(): void {
+
+	$selected       = webp_uploads_get_image_output_format();
 	$avif_supported = webp_uploads_mime_type_supported( 'image/avif' );
 	$webp_supported = webp_uploads_mime_type_supported( 'image/webp' );
 


### PR DESCRIPTION
## Summary

This is a sub-PR of https://github.com/WordPress/performance/pull/1273. Instead of disabling the checkbox field for the picture element row, it proposes to hide the row entirely when the JPEG checkbox is unchecked:

[Screen recording 2024-06-04 11.49.16.webm](https://github.com/adamsilverstein/performance/assets/134745/0bf58de9-40b6-4b6c-9f94-0bb30b58d8c3)

A couple possible benefits here:

1. If the picture element checkbox was checked, but someone disables the JPEG output, upon saving the picture element checkbox will then become unchecked (even though it is disabled). By simply hiding the row, the checkbox state will be preserved and the option in the DB won't be changed. Compare with current behavior in https://github.com/WordPress/performance/pull/1273:

[Screen recording 2024-06-04 11.55.04.webm](https://github.com/adamsilverstein/performance/assets/134745/a768e2fb-c87b-4517-a4a2-eaa8cc99c366)

2. The row is only relevant to be shown when the JPEG output checkbox is enabled. If it isn't checked, then someone may be confused as to why the checkbox is disabled and how it could be enabled.